### PR TITLE
Fixes TypeError when calling Refund, Wallet methods, fixes #3

### DIFF
--- a/refunds.js
+++ b/refunds.js
@@ -2,7 +2,7 @@ const RequestClient = require('./requests');
 
 class Refunds extends RequestClient {
   list() {
-    return this.send(null, '/api/v1/chargebacks/', 'GET');
+    return this.send({}, '/api/v1/chargebacks/', 'GET');
   }
 
   create(payload) {
@@ -10,7 +10,7 @@ class Refunds extends RequestClient {
   }
 
   get(chargebackID) {
-    return this.send(null, `/api/v1/chargebacks/${chargebackID}/`, 'GET');
+    return this.send({}, `/api/v1/chargebacks/${chargebackID}/`, 'GET');
   }
 }
 

--- a/wallets.js
+++ b/wallets.js
@@ -2,7 +2,7 @@ const RequestClient = require('./requests');
 
 class Wallet extends RequestClient {
   list() {
-    return this.send(null, '/api/v1/wallets/', 'GET');
+    return this.send({}, '/api/v1/wallets/', 'GET');
   }
   create(payload) {
     return this.send(payload, '/api/v1/wallets/', 'POST');
@@ -22,11 +22,11 @@ class Wallet extends RequestClient {
   }
 
   get(walletID) {
-    return this.send(null, `/api/v1/wallets/${walletID}/`, 'GET');
+    return this.send({}, `/api/v1/wallets/${walletID}/`, 'GET');
   }
 
   transactions(walletID) {
-    return this.send(null, `/api/v1/wallets/${walletID}/transactions/`, 'GET');
+    return this.send({}, `/api/v1/wallets/${walletID}/transactions/`, 'GET');
   }
 
   fundMPesa(payload, walletID) {


### PR DESCRIPTION
This commit fixes the bug reported on #3.

With this, users can now retrieve data from several Wallet, Refund methods. Otherwise, a `TypeError` would be raised.